### PR TITLE
Add OAuth authentication methods

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -6,6 +6,7 @@ detectors:
   FeatureEnvy:
     exclude:
       - "Virtuous::Client#connection"
+      - "Virtuous::Client#unauthorized_connection"
       - "Hash#deep_transform_keys"
       - "FaradayMiddleware::ParseOj#on_complete"
   NilCheck:
@@ -24,3 +25,8 @@ detectors:
   ControlParameter:
     exclude:
       - "Virtuous::Client#initialize"
+  NilCheck:
+    enabled: false
+  TooManyInstanceVariables:
+    exclude:
+      - "Virtuous::Client"

--- a/lib/virtuous.rb
+++ b/lib/virtuous.rb
@@ -6,5 +6,7 @@ require_relative 'virtuous/client'
 
 ##
 # Virtuous module documentation.
+#
+# Go to Virtuous::Client to see the documentation of the client.
 module Virtuous
 end

--- a/lib/virtuous/client.rb
+++ b/lib/virtuous/client.rb
@@ -12,26 +12,98 @@ module Virtuous
   #     )
   #
   # See Virtuous::Client::new for a full list of supported configuration options.
+  #
+  # Check resource modules to see available client methods:
+  #
+  # - Virtuous::Client::Contact
+  # - Virtuous::Client::Individual
+  # - Virtuous::Client::Gift
   class Client
     include Virtuous::Client::Contact
     include Virtuous::Client::Individual
 
-    attr_reader :api_key, :base_url
+    ##
+    # Api key used for authentication.
+    attr_reader :api_key
+    ##
+    # Base url that the client will use to form URLs.
+    # default: `https://api.virtuoussoftware.com`.
+    attr_reader :base_url
+    ##
+    # Access token used for OAuth authentication.
+    attr_reader :access_token
+    ##
+    # Token used to refresh the access token when it has expired.
+    attr_reader :refresh_token
+    ##
+    # Expiration date of the access token.
+    attr_reader :expires_at
+    ##
+    # True if the access token has been refreshed.
+    attr_reader :refreshed
 
     ##
-    # To be able to create a client, you need to set the api_key.
-    # This can also be done by setting the `VIRTUOUS_KEY` environment variable.
-    #
-    # :args: api_key:, base_url:
-    #
     # ### Options
-    # - `:api_key`: The key for the API.
+    #
     # - `:base_url`: The base url to use for API calls.
-    def initialize(api_key: ENV.fetch('VIRTUOUS_KEY', nil), base_url: 'https://api.virtuoussoftware.com')
-      raise ArgumentError, 'api_key is required' if api_key.nil?
+    # default: `https://api.virtuoussoftware.com`.
+    # - `:api_key`: The key for the API.
+    # - `:email`: The email of the OAuth user.
+    # - `:password`: The password of the OAuth user.
+    # - `:access_token`: The OAuth access token.
+    # - `:refresh_token`: The OAuth refresh token.
+    # - `:expires_at`: The expiration date of the access token.
+    #
+    # ### Authentication
+    #
+    # #### Api key auth
+    #
+    # To generate an api key you need to visit the
+    # [virtuous connect dashboard](https://connect.virtuoussoftware.com/).
+    # Then you can use the key by setting the `api_key` param while creating the client or
+    # by setting the `VIRTUOUS_KEY` environment variable beforehand.
+    #
+    # #### Oauth
+    #
+    # First, an access token needs to be fetched by providing a user's email and password.
+    # This will return an access token that lasts for 15 days, and a refresh token that should be
+    # stored and used to create clients in the future.
+    # The client will use the expiry date of the access token to automatically determine when a
+    # new one needs to be fetched.
+    #
+    #     client = Virtuous::Client.new(email: user.email, password: password)
+    #     user.update(
+    #       access_token: client.access_token, refresh_token: client.refresh_token,
+    #       token_expiration: client.expires_at
+    #     )
+    #
+    #     # Afterwards
+    #
+    #     client = Virtuous::Client.new(
+    #       access_token: user.access_token, refresh_token: user.refresh_token,
+    #       expires_at: user.token_expiration
+    #     )
+    #
+    #     # Use client
+    #
+    #     if client.refreshed
+    #       # Update values if they changed
+    #       user.update(
+    #         access_token: client.access_token, refresh_token: client.refresh_token,
+    #         token_expiration: client.expires_at
+    #       )
+    #     end
+    #
+    def initialize(config)
+      read_config(config)
 
-      @api_key = api_key
-      @base_url = base_url
+      @refreshed = false
+
+      return unless api_key.nil?
+
+      return if use_access_token?
+
+      authenticate(config[:email], config[:password])
     end
 
     [:get, :post, :delete, :patch, :put].each do |http_method|
@@ -41,6 +113,40 @@ module Virtuous
     end
 
     private
+
+    def authenticate(email, password)
+      raise ArgumentError, 'No valid authentication options' unless email && password
+
+      data = { grant_type: 'password', username: email, password: password }
+      get_access_token(data)
+    end
+
+    def read_config(config)
+      @api_key = config[:api_key] || ENV.fetch('VIRTUOUS_KEY', nil)
+      @base_url = config[:base_url] || 'https://api.virtuoussoftware.com'
+      @access_token = config[:access_token]
+      @refresh_token = config[:refresh_token]
+      @expires_at = config[:expires_at]
+    end
+
+    def use_access_token?
+      !access_token.nil? || !refresh_token.nil?
+    end
+
+    def get_access_token(body)
+      response = unauthorized_connection.post('/Token', URI.encode_www_form(body)).body
+      @access_token = response['access_token']
+      @expires_at = Time.parse(response['.expires'])
+      @refresh_token = response['refresh_token']
+      @refreshed = true
+    end
+
+    def check_token_expiration
+      if !refresh_token.nil? &&
+         ((!expires_at.nil? && expires_at < Time.now) || access_token.nil?)
+        get_access_token({ grant_type: 'refresh_token', refresh_token: refresh_token })
+      end
+    end
 
     def parse(data)
       data = JSON.parse(data) if data.is_a?(String)
@@ -52,10 +158,27 @@ module Virtuous
       data.deep_transform_keys { |key| key.to_s.camelize }
     end
 
+    def bearer_token
+      if api_key.nil?
+        check_token_expiration
+        return access_token
+      end
+
+      api_key
+    end
+
     def connection
       Faraday.new({ url: base_url }) do |conn|
         conn.request :json
-        conn.request :authorization, 'Bearer', -> { api_key }
+        conn.request :authorization, 'Bearer', -> { bearer_token }
+        conn.response :oj
+        conn.use FaradayMiddleware::VirtuousErrorHandler
+      end
+    end
+
+    def unauthorized_connection
+      Faraday.new({ url: base_url }) do |conn|
+        conn.request :json
         conn.response :oj
         conn.use FaradayMiddleware::VirtuousErrorHandler
       end

--- a/spec/support/virtuous_mock.rb
+++ b/spec/support/virtuous_mock.rb
@@ -46,6 +46,23 @@ class VirtuousMock < Sinatra::Base
     end
   end
 
+  # Auth request
+
+  post '/Token' do
+    content_type :json
+    status 200
+    {
+      access_token: 'new_access_token',
+      token_type: 'bearer',
+      expires_in: 1_295_999,
+      refresh_token: 'new_refresh_token',
+      userName: 'user@email.com',
+      twoFactorEnabled: 'False',
+      '.issued': Time.now.gmtime,
+      '.expires': (Time.now + 1_295_999).gmtime
+    }.to_json
+  end
+
   private
 
   def json_response(response_code, file_name)


### PR DESCRIPTION
# Description:
Added methods to authenticate API calls through OAuth.

[Video of me running the following commands](https://drive.google.com/file/d/1A629Ej3YXkHMc7lczp4StWjpJZjV3xlD/view?usp=sharing):
```rb
password_client = Virtuous::Client.new(email: ENV['TEST_EMAIL'], password: ENV['TEST_PASSWORD'])

password_client.find_individual_by_email('jorge@eagerworks.com')

access_token_client = Virtuous::Client.new(
  access_token: password_client.access_token, refresh_token: password_client.refresh_token,
  expires_at: password_client.expires_at
)

access_token_client.find_individual_by_email('jorge@eagerworks.com')
```