### PR TITLE
Added logger option to client

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -30,3 +30,6 @@ detectors:
   TooManyInstanceVariables:
     exclude:
       - "Virtuous::Client"
+  InstanceVariableAssumption:
+    exclude:
+      - "Virtuous::Client"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,3 +81,7 @@ Style/SymbolArray:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*
+
+Naming/MemoizedInstanceVariableName:
+  Exclude:
+    - lib/virtuous/client.rb

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ end
 
 desc 'Launch a pry shell with libraries loaded'
 task pry: :environment do
-  @client = Virtuous::Client.new if ENV['VIRTUOUS_KEY']
+  @client = Virtuous::Client.new(logger: !ENV['CLIENT_LOGGER'].nil?) if ENV['VIRTUOUS_KEY']
 
   require 'pry'
   Pry.start


### PR DESCRIPTION
Similar to the `logger` client option in [rock_rms](https://github.com/taylorbrooks/rock_rms), setting this param to true will make the Faraday connection log the HTTP internal events.

Also, deleted attribute accessors for ivars that don't need to be accessed from outside.

Video:
https://github.com/taylorbrooks/virtuous/assets/39068923/00053521-f2ab-415f-9156-9d9ae30bbdce

