### PR TITLE
Add support for two-factor auth

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -30,3 +30,6 @@ detectors:
   TooManyInstanceVariables:
     exclude:
       - "Virtuous::Client"
+  InstanceVariableAssumption:
+    exclude:
+      - "Virtuous::Client"

--- a/spec/support/virtuous_mock.rb
+++ b/spec/support/virtuous_mock.rb
@@ -50,6 +50,17 @@ class VirtuousMock < Sinatra::Base
 
   post '/Token' do
     content_type :json
+
+    body = URI.decode_www_form(request.body.read).to_h
+
+    if body['username'] == 'otp@user.com' && body['otp'].nil?
+      status 202
+      return {
+        error: 'awaiting_verification',
+        error_description: '2-step verification code (OTP) sent.'
+      }.to_json
+    end
+
     status 200
     {
       access_token: 'new_access_token',


### PR DESCRIPTION
Now the authentication method can receive an OTP value, and it will return different values to differentiate when two-factor authentication is required.
To do that, I had to remove it from the client initiator to a public method, so now to use password authentication first you need to create a client and the call `client.authenticate`.

Video:
https://github.com/taylorbrooks/virtuous/assets/39068923/d1892526-6028-45a7-b42b-bb60cfa367d0

