### PR TITLE
Add SSL options to client

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -21,6 +21,7 @@ detectors:
     exclude:
       - "Hash#deep_transform_keys"
       - "Virtuous::Client#connection"
+      - "Virtuous::Client#unauthorized_connection"
       - "FaradayMiddleware::VirtuousErrorHandler#on_complete"
   ControlParameter:
     exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,3 +81,7 @@ Style/SymbolArray:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*
+
+Naming/MemoizedInstanceVariableName:
+  Exclude:
+    - lib/virtuous/client.rb


### PR DESCRIPTION
Now the Client initializer takes an `:ssl` option to pass to the Faraday connection as SSL options.

Also: 
- Removed attr readers for ivars that don't need to be seen from outside
- Refactored repetitive code on `read_config` and `connection` methods