### PR TITLE
Moved Faraday Middleware to Virtuous namespace

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -8,7 +8,7 @@ detectors:
       - "Virtuous::Client#connection"
       - "Virtuous::Client#unauthorized_connection"
       - "Virtuous::HashHelper#self.deep_transform_keys"
-      - "FaradayMiddleware::ParseOj#on_complete"
+      - "Virtuous::FaradayMiddleware::ParseOj#on_complete"
   NilCheck:
     exclude:
       - "Virtuous::Client#initialize"
@@ -22,7 +22,7 @@ detectors:
       - "Virtuous::HashHelper#self.deep_transform_keys"
       - "Virtuous::Client#connection"
       - "Virtuous::Client#unauthorized_connection"
-      - "FaradayMiddleware::VirtuousErrorHandler#on_complete"
+      - "Virtuous::FaradayMiddleware::VirtuousErrorHandler#on_complete"
   ControlParameter:
     exclude:
       - "Virtuous::Client#initialize"

--- a/lib/virtuous/client.rb
+++ b/lib/virtuous/client.rb
@@ -264,7 +264,7 @@ module Virtuous
         conn.request :json
         conn.response :oj
         conn.response :logger, @logger if @logger
-        conn.use FaradayMiddleware::VirtuousErrorHandler
+        conn.use Virtuous::FaradayMiddleware::VirtuousErrorHandler
         conn.adapter @adapter
         yield(conn) if block_given?
       end

--- a/lib/virtuous/error.rb
+++ b/lib/virtuous/error.rb
@@ -1,3 +1,5 @@
+require 'faraday'
+
 module Virtuous # :nodoc: all
   class Error < StandardError; end
   class BadGateway < Error; end
@@ -9,46 +11,45 @@ module Virtuous # :nodoc: all
   class NotFound < Error; end
   class ServiceUnavailable < Error; end
   class Unauthorized < Error; end
-end
 
-require 'faraday'
-module FaradayMiddleware
-  class VirtuousErrorHandler < Faraday::Middleware
-    ERROR_STATUSES = (400..600).freeze
+  module FaradayMiddleware
+    class VirtuousErrorHandler < Faraday::Middleware
+      ERROR_STATUSES = (400..600).freeze
 
-    ##
-    # Throws an exception for responses with an HTTP error code.
-    def on_complete(env)
-      message = error_message(env)
+      ##
+      # Throws an exception for responses with an HTTP error code.
+      def on_complete(env)
+        message = error_message(env)
 
-      case env[:status]
-      when 400
-        raise Virtuous::BadRequest, message
-      when 401
-        raise Virtuous::Unauthorized, message
-      when 403
-        raise Virtuous::Forbidden, message
-      when 404
-        raise Virtuous::NotFound, message
-      when 500
-        raise Virtuous::InternalServerError, message
-      when 502
-        raise Virtuous::BadGateway, message
-      when 503
-        raise Virtuous::ServiceUnavailable, message
-      when 504
-        raise Virtuous::GatewayTimeout, message
-      when 520
-        raise Virtuous::CloudflareError, message
-      when ERROR_STATUSES
-        raise Virtuous::Error, message
+        case env[:status]
+        when 400
+          raise Virtuous::BadRequest, message
+        when 401
+          raise Virtuous::Unauthorized, message
+        when 403
+          raise Virtuous::Forbidden, message
+        when 404
+          raise Virtuous::NotFound, message
+        when 500
+          raise Virtuous::InternalServerError, message
+        when 502
+          raise Virtuous::BadGateway, message
+        when 503
+          raise Virtuous::ServiceUnavailable, message
+        when 504
+          raise Virtuous::GatewayTimeout, message
+        when 520
+          raise Virtuous::CloudflareError, message
+        when ERROR_STATUSES
+          raise Virtuous::Error, message
+        end
       end
-    end
 
-    private
+      private
 
-    def error_message(env)
-      "#{env[:status]}: #{env[:url]} #{env[:body]}"
+      def error_message(env)
+        "#{env[:status]}: #{env[:url]} #{env[:body]}"
+      end
     end
   end
 end

--- a/lib/virtuous/parse_oj.rb
+++ b/lib/virtuous/parse_oj.rb
@@ -1,24 +1,26 @@
 require 'oj'
 
-module FaradayMiddleware
-  class ParseOj < Faraday::Middleware
-    ##
-    # Parses JSON responses.
-    def on_complete(env)
-      body = env[:body]
-      env[:body] = if empty_body?(body.strip)
-                     nil
-                   else
-                     Oj.load(body, mode: :compat)
-                   end
-    end
+module Virtuous
+  module FaradayMiddleware
+    class ParseOj < Faraday::Middleware
+      ##
+      # Parses JSON responses.
+      def on_complete(env)
+        body = env[:body]
+        env[:body] = if empty_body?(body.strip)
+                       nil
+                     else
+                       Oj.load(body, mode: :compat)
+                     end
+      end
 
-    private
+      private
 
-    def empty_body?(body)
-      body.empty? && body == ''
+      def empty_body?(body)
+        body.empty? && body == ''
+      end
     end
   end
 end
 
-Faraday::Response.register_middleware(oj: FaradayMiddleware::ParseOj)
+Faraday::Response.register_middleware(oj: Virtuous::FaradayMiddleware::ParseOj)


### PR DESCRIPTION
The faraday middleware declared in the virtuous gem was overwriting the one declared on [rock_rms](https://github.com/taylorbrooks/rock_rms). I moved it to the virtuous namespace to avoid the problem.

I also checked if there was any other code outside of the Virtuous namespace, and we seem to be good now.

It may be a good idea to check the same thing on the rock_rms gem as well.

Close T-10153